### PR TITLE
add meta viewport tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 {% if page.layout == "page" %}
 {% capture page_title %}
 {{ site.title }} - {{ page.title }}


### PR DESCRIPTION
This PR adds a [meta viewport tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag) (`<meta name="viewport" content="width=device-width, initial-scale=1">`) to the site's head to enable "responsiveness" on mobile.

Currently:

![Chimera linux' website on mobile firefox without the meta viewport tag. It looks like the desktop site but zoomed out.](https://user-images.githubusercontent.com/18014039/169530203-dca7d8b4-2759-4869-b037-7aa84359f61a.jpg)

With the meta viewport tag:

![Chimera linux' website on mobile firefox with the meta viewport tag. It looks like the desktop site but zoomed in.](https://user-images.githubusercontent.com/18014039/169530279-6c762383-c6e5-4043-86da-87e2eb9cc8fc.jpg)
