### PR TITLE
Even smaller screen support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=0.78">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 {% if page.layout == "page" %}
 {% capture page_title %}
 {{ site.title }} - {{ page.title }}

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -272,3 +272,12 @@ a:active { text-decoration: none; }
         --side-padding: var(--content-halfgap);
     }
 }
+
+@media (max-width: 480px) {
+    /* make nav bar scrollable on even smaller screens */
+    #header .menu {
+        overflow-x: auto;
+        max-width: 100vw;
+        justify-content: left;
+    }
+}

--- a/assets/css/mainpage.css
+++ b/assets/css/mainpage.css
@@ -290,3 +290,28 @@ body {
         margin-bottom: var(--content-halfgap);
     }
 }
+
+@media (max-width: 480px) {
+    /* keep logo aspect ratio */
+    #logo {
+        max-height: var(--logo-height);
+        max-width: 100%;
+        height: auto !important;
+    }
+
+    #container {
+        grid-template-columns: minmax(0, 1fr) minmax(var(--column-minwidth), var(--column-width));
+    }
+
+    /* tiles should use as much height as they need */
+    .tile {
+        height: auto !important;
+    }
+
+    /* first children of #container that have an id
+    that doesn't end in "bg", get 1rem x padding */
+    #container > :not(nav, [id$='bg']) {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+}

--- a/assets/css/post.css
+++ b/assets/css/post.css
@@ -82,3 +82,9 @@ body {
         padding-bottom: var(--table-pad);
     }
 }
+
+@media (max-width: 480px) {
+    #container {
+        grid-template-columns: minmax(0, 1fr) minmax(var(--column-minwidth), var(--column-width)) minmax(0, 1fr);
+    }
+}


### PR DESCRIPTION
Follow-up from #1 

To avoid overflow on smaller screens, this PR changes the following on width < 480px:

- Makes the navbar scrollable
- Makes the logo "responsive" while keeping its aspect ratio (on mainpage.css)
- Changes the grid a bit so it doesn't have min width
- Makes tiles take as much height as they need (the "Read more" anchor would float outside of them) (on mainpage.css)
- Attempts to add some x axis padding on most elements under #container (on mainpage.css)


It also sets initial-scale back to 1.

mainpage:

https://user-images.githubusercontent.com/18014039/169591975-934d65f5-efd5-40ab-8f9c-8998ff5e58a3.mp4

> (ALT text: A screenrecording of Firefox Devtools' responsive design mode, showcasing https://chimera-linux.org/ on different screen widths. When the size reaches width < 480px, we notice that there's no more overflow on the x axis and the navbar is now scrollable.)

post:

https://user-images.githubusercontent.com/18014039/169592271-dfbb7763-f38f-4c16-9e2f-25b3154b4d03.mp4

> (ALT text: A screenrecording of Firefox Devtools' responsive design mode, showcasing https://chimera-linux.org/downloads/ on different screen widths. When the size reaches width < 480px, we notice that there's no more overflow on the x axis and the navbar is now scrollable.)


Let me know if I should change anything, that was the quickest solution I could come up with without replacing grid!