### PR TITLE
fix: add fallback values for font-family

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -38,7 +38,7 @@ body {
     /* base attributes */
     background-color: var(--color-bg);
     color: var(--color-fontdef);
-    font-family: "Noto Sans";
+    font-family: "Noto Sans, sans-serif";
     font-size: var(--content-fontsize);
     margin: 0;
     padding: 0;
@@ -85,7 +85,7 @@ ul, ol {
 }
 
 h1, h2, h3, h4, h5, h6 {
-    font-family: "Poppins";
+    font-family: "Poppins, sans-serif";
     font-weight: 500;
     margin-top: var(--content-altgap);
     margin-bottom: var(--content-halfgap);

--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -117,7 +117,7 @@ ol {
 
 /* normally monospace text can blend into the rest, so style it accordingly */
 code, .highlight pre {
-    font-family: "Noto Sans Mono";
+    font-family: "Noto Sans Mono, monospace";
     background-color: var(--color-codebg);
     border: 1px solid var(--color-codebg);
     border-radius: 3px;

--- a/assets/css/mainpage.css
+++ b/assets/css/mainpage.css
@@ -126,7 +126,7 @@ body {
 
 .tile .more > a {
     color: var(--color-fontlight);
-    font-family: "Poppins";
+    font-family: "Poppins, sans-serif";
     font-weight: 400;
     font-size: var(--tilelink-fontsize);
     margin-bottom: var(--content-halfgap);

--- a/assets/css/post.css
+++ b/assets/css/post.css
@@ -57,7 +57,7 @@ body {
 
 #content .post_date {
     display: block;
-    font-family: "Poppins";
+    font-family: "Poppins, sans-serif";
     font-weight: 500;
     color: var(--color-chead);
     font-size: 17pt;


### PR DESCRIPTION
If a user is using web browsers like Firefox and enforcing their own and/or blocking remote fonts, the `font-family` values which enforce a single font like `Noto Sans Mono` don't work as expected. Adding fallback values of `monospace` and `sans-serif` fixes this issue.