### PR TITLE
add note about system logging

### DIFF
--- a/_docs/configuration/post-installation.md
+++ b/_docs/configuration/post-installation.md
@@ -103,6 +103,17 @@ There are two files that should be of interest:
 Both files have detailed man pages, see `man 5 console-setup` as well
 as `man 5 keyboard`.
 
+## System logging
+
+The default logging system on Chimera is `syslog-ng`, which is part of
+`base-full`. Enable the syslog daemon as follows:
+
+```
+# dinitctl enable syslog-ng
+```
+
+By default logs are written to `/var/log/messages`.
+
 ## Additional software
 
 If you need software beyond what the `main` repository provides, you


### PR DESCRIPTION
I was wondering why my system didn't seem to have system logs since I was aware that `syslog-ng` was part of the base install. Turns out I needed to enable it and I figured this was worth noting in the docs.