### PR TITLE
Rename Docs to Documentation in header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -56,7 +56,7 @@
             <li><a href="/news">News</a></li>
             <li><a href="/downloads">Downloads</a></li>
             <li><a href="{{ site.pkgs_link }}">Packages</a></li>
-            <li><a href="/docs">Docs</a></li>
+            <li><a href="/docs">Documentation</a></li>
             <li><a href="/community">Community</a></li>
             <li><a href="/development">Development</a></li>
         </ul>


### PR DESCRIPTION
Every other thing in header points to page with the same name apart this one.