### PR TITLE
Include feed link tag on all pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,12 +33,12 @@
 <link rel="apple-touch-icon" type="image/png" sizes="152x152" href="/assets/icons/favicon152.png">
 <link rel="apple-touch-icon" type="image/png" sizes="167x167" href="/assets/icons/favicon167.png">
 <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="/assets/icons/favicon180.png">
+<link rel="alternate" type="application/atom+xml" title="Chimera Linux news feed" href="/atom.xml" />
 <link rel="stylesheet" href="/assets/css/reset.css">
 <link rel="stylesheet" href="/assets/css/fonts.css">
 <link rel="stylesheet" href="/assets/css/common.css">
 {% if page.layout == "main" %}
 <link rel="stylesheet" href="/assets/css/mainpage.css">
-<link rel="alternate" type="application/atom+xml" title="Chimera Linux news feed" href="/atom.xml" />
 {% else %}
 <link rel="stylesheet" href="/assets/css/post.css">
 {% endif %}


### PR DESCRIPTION
I tried to subscribe to news feed from the news page and my feed reader said there was no feed found. This PR includes the `link` tag on all pages so it can be auto-discovered not matter what page you're on.