### PR TITLE
install: Add -U to genfstab examples

### DIFF
--- a/_docs/installation/install.md
+++ b/_docs/installation/install.md
@@ -250,14 +250,14 @@ The installation scripts come with a `fstab` generator. You can invoke
 it like:
 
 ```
-# genfstab / >> /etc/fstab
+# genfstab -U / >> /etc/fstab
 ```
 
 It is also possible to invoke it from the outside of the system, e.g.
 like:
 
 ```
-# genfstab /media/root >> /media/root/etc/fstab
+# genfstab -U /media/root >> /media/root/etc/fstab
 ```
 
 You might want to manually edit the generated `fstab` to remove useless


### PR DESCRIPTION
I think using UUIDs in fstab is generally preferred, and the example later on uses them as well:

> An example `/etc/fstab` for a root partition and ESP may look like this:
> ```
> UUID=... / ext4 defaults 0 1
> UUID=... /boot/efi vfat defaults 0 2
> ```

With this change the generated fstab will better match the example.