### PR TITLE
Remove All Things Linux mirror link

### DIFF
--- a/_docs/apk/mirrors.md
+++ b/_docs/apk/mirrors.md
@@ -33,7 +33,6 @@ The following mirrors are available:
 * [https://au.mirror.7bit.org/chimera](https://au.mirror.7bit.org/chimera) (hosted by wezm, Brisbane, Australia)
 * [https://mirror.accum.se/mirror/chimera-linux.org](https://mirror.accum.se/mirror/chimera-linux.org) (hosted by ACC, Umeå, Sweden)
 * [https://mirror.meowsmp.net/chimera-linux](https://mirror.meowsmp.net/chimera-linux) (hosted by MeowIce, Hanoi, Vietnam)
-* [https://mirror.allthingslinux.org/chimera](https://mirror.allthingslinux.org/chimera) (hosted by All Things Linux, Quebec, Canada)
 
 This information is also available in a pure text form [here](https://repo.chimera-linux.org/mirrors.txt).
 


### PR DESCRIPTION
Unfortunately, ATL has dissolved after the owner turned out to be a terrible person (I am not going into the specifics here).

The mirror now has this banner:

<img width="841" height="96" alt="image" src="https://github.com/user-attachments/assets/f8c2df7a-ac24-4b70-bbcc-31418a346c75" />
