### PR TITLE
Remove obsolete ZFS notes

### DIFF
--- a/_docs/installation/partitioning/encrypted.md
+++ b/_docs/installation/partitioning/encrypted.md
@@ -263,14 +263,6 @@ When doing root on ZFS, LUKS does not influence the `root=`. You just have to
 specify something like `root=ZFS=mypool/root/whatever` and the initramfs will
 take care of the rest, provided the `crypttab` mappings are correctly set up.
 
-The initramfs hook scripts currently don't detect the root filesystem when it's
-on ZFS (resulting in warnings while creating the initramfs which can be ignored),
-so you need to use the `initramfs` option in `crypttab`, e.g.:
-
-```
-# echo crypt /dev/sda3 none luks,initramfs > /etc/crypttab
-```
-
 ### Bootloader and kernel command line
 
 With full disk encryption (i.e. encrypted `/boot`), you will need to enable this

--- a/_docs/installation/partitioning/zfs.md
+++ b/_docs/installation/partitioning/zfs.md
@@ -112,6 +112,3 @@ simply specify the same `root=` as you would with an unencrypted system.
 
 This is because ZFS is pool-based and the pool will be identified on the
 mapper devices automatically, just like for any other block device.
-
-You also need to use the `initramfs` option in your `crypttab`, see the
-`Disk encryption` section.


### PR DESCRIPTION
With ZFS support now added to cryptsetup-scripts, notes about needing
`initramfs` in `crypttab` are obsolete.